### PR TITLE
Pass Lambda errors as strings, not objects

### DIFF
--- a/functions/userInvitation/src/index.js
+++ b/functions/userInvitation/src/index.js
@@ -14,7 +14,7 @@ export const handle = (data, context, callback) => {
   const ajv = new Ajv({ allErrors: true });
   const isValid = ajv.validate(schema, data);
   if (!isValid) {
-    return callback(ajv.errors);
+    return callback(`Validation errors: ${ajv.errorsText()}`); // eslint-disable-line
   }
   console.log(
     `Validated data. ${context.getRemainingTimeInMillis()}ms remaining until timeout.`
@@ -34,7 +34,9 @@ export const handle = (data, context, callback) => {
     {
       From: site.fromEmail,
       To: data.user.email,
-      Subject: `You've been invited to join ${data.group.name} on ${site.name}!`,
+      Subject: `You've been invited to join ${data.group.name} on ${
+        site.name
+      }!`,
       TextBody: text,
       HtmlBody: html,
       Tag: "invite"

--- a/functions/userInvitation/src/index.test.js
+++ b/functions/userInvitation/src/index.test.js
@@ -22,13 +22,12 @@ describe("userInvitation handler", () => {
     const callback = jest.fn();
     handle(data, context, callback);
 
-    const errors = callback.mock.calls[0][0];
-    expect(errors).toHaveLength(4);
-    const messages = errors.map(error => error.message);
-    expect(messages[0]).toContain("baseUrl");
-    expect(messages[1]).toContain("user");
-    expect(messages[2]).toContain("invitedBy");
-    expect(messages[3]).toContain("group");
+    const errorsText = callback.mock.calls[0][0];
+    expect(errorsText.startsWith("Validation errors: ")).toBe(true);
+    expect(errorsText).toContain("baseUrl");
+    expect(errorsText).toContain("user");
+    expect(errorsText).toContain("invitedBy");
+    expect(errorsText).toContain("group");
   });
 
   it("sends an email when called with correct arguments", () => {

--- a/functions/userReminder/src/index.js
+++ b/functions/userReminder/src/index.js
@@ -15,7 +15,7 @@ export const handle = (data, context, callback) => {
   const ajv = new Ajv({ allErrors: true });
   const isValid = ajv.validate(schema, data);
   if (!isValid) {
-    return callback(ajv.errors);
+    return callback(`Validation errors: ${ajv.errorsText()}`); // eslint-disable-line
   }
   console.log(
     `Validated data. ${context.getRemainingTimeInMillis()}ms remaining until timeout.`

--- a/functions/userReminder/src/index.test.js
+++ b/functions/userReminder/src/index.test.js
@@ -22,11 +22,11 @@ describe("userReminder handler", () => {
     const callback = jest.fn();
     handle(data, context, callback);
 
-    const errors = callback.mock.calls[0][0];
-    expect(errors).toHaveLength(3);
-    expect(errors[0].message).toContain("baseUrl");
-    expect(errors[1].message).toContain("user");
-    expect(errors[2].message).toContain("event");
+    const errorsText = callback.mock.calls[0][0];
+    expect(errorsText.startsWith("Validation errors: ")).toBe(true);
+    expect(errorsText).toContain("baseUrl");
+    expect(errorsText).toContain("user");
+    expect(errorsText).toContain("event");
   });
 
   it("sends an email when called with correct arguments", () => {
@@ -36,13 +36,13 @@ describe("userReminder handler", () => {
         email: "foo@example.com",
         firstName: "Test",
         locale: "en",
-        timeZone: "America/New_York",
+        timeZone: "America/New_York"
       },
       event: {
         id: 1,
         title: "Pool Party",
         startAt: "2017-02-01T10:00:00Z",
-        endAt: "2017-02-01T22:00:00Z",
+        endAt: "2017-02-01T22:00:00Z"
       }
     };
     const context = new MockContext();
@@ -51,7 +51,7 @@ describe("userReminder handler", () => {
 
     expect(mockSendEmail).toHaveBeenCalledWith(
       {
-        From:  "hi@example-website.com",
+        From: "hi@example-website.com",
         To: "foo@example.com",
         Subject: "Looking forward to seeing you at Pool Party!",
         TextBody: expect.any(String),


### PR DESCRIPTION
Because Lambda turns JS Objects into the string `[object Object]` :sob: